### PR TITLE
js로 구현한 Densecap API과 Papago Translate API 연결 준비 파일 추가

### DIFF
--- a/TMP-HIK/densecap.js
+++ b/TMP-HIK/densecap.js
@@ -1,0 +1,27 @@
+// INCLUDED deepai.min.js as a script tag in HTML file
+
+// 개인 API
+deepai.setApiKey('bd06d8eb-777b-4434-afd3-fa45a152bc5b');
+
+// 나중에 url을 받아야 한다면 입력인자로 url 넣고
+// image : url 로 수정해야 할 것 같다.
+// 참고 : https://developers.google.com/web/fundamentals/primers/async-functions?hl=ko
+
+async function densecapAPI() { //urllink) {
+    let str = "";
+    var resp = await deepai.callStandardApi("densecap", {
+            image : "http://res.heraldm.com/content/image/2021/08/08/20210808000215_0.jpg"
+            //image : urllink
+        });
+        
+    // 분석된 문장을 다 가져와서 알고리즘에 넣을 배열에 넣기
+    for (var i = 0; i < 5; i++ ){  // 최상위 5개만 가져오도록 한다.
+        let sentence = resp["output"]["captions"][i]["caption"];
+        str += (sentence + ". ");
+    }
+    document.write(str);
+    return str;
+}
+
+densecapAPI();
+//export {  densecapAPI };

--- a/TMP-HIK/manifest.json
+++ b/TMP-HIK/manifest.json
@@ -1,0 +1,11 @@
+{
+    "manifest_version": 1,
+    "version": "0.0.1",
+    "name": "Densecap API 실행",
+    "description": "최상위 5개의 결과만 가져온다.",
+  
+    "content_scripts": [{
+        "js": ["densecap.js"],
+        "matches": ["https://www.mfds.go.kr/*"]
+    }]
+}

--- a/TMP-HIK/package.json
+++ b/TMP-HIK/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "check",
+  "version": "1.0.0",
+  "description": "test for densecapAPI and transAPI",
+  "main": "densecap.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "satelliteheart29",
+  "license": "ISC",
+  "type": "module"
+}

--- a/TMP-HIK/test.html
+++ b/TMP-HIK/test.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="ko">
+
+<head>
+    <meta charset="UTF-8">
+    <link rel="manifest" href="manifest.json">
+    <title>TEST</title>
+</head>
+
+<body>
+    <h1>3-4초 후 captioning 문장 나옴</h1>
+    <script src="https://cdnjs.deepai.org/deepai.min.js"></script>
+    <script type="text/javascript" src="./densecap.js"></script>
+    <!--<script type="module" src="./trans.js"></script>-->
+</body>
+
+</html>

--- a/TMP-HIK/trans.js
+++ b/TMP-HIK/trans.js
@@ -1,0 +1,37 @@
+// 분석한 문장 가져오기
+// 이 부분 실행하려면 densecap.js 수정해야 한다.
+import { densecapAPI } from "./densecap.js";
+const query = await densecapAPI();
+console.log(query);
+
+
+var express = require('express');
+var app = express();
+var client_id = "3WvS7UX94yDQBUtLWtja"; //'YOUR_CLIENT_ID';
+var client_secret = '0Wagq7KbQf'; //YOUR_CLIENT_SECRET';
+
+
+app.get('/translate', function (req, res) {
+  var api_url = 'https://openapi.naver.com/v1/papago/n2mt';
+  var request = require('request');
+  var options = {
+      url: api_url,
+      form: {'source':'en', 'target':'ko', 'text':query},
+      headers: {'X-Naver-Client-Id':client_id, 'X-Naver-Client-Secret': client_secret}
+  };
+  request.post(options, function (error, response, body) {
+    if (!error && response.statusCode == 200) {
+      
+      res.writeHead(200, {'Content-Type': 'text/json;charset=utf-8'});
+      res.end(body);
+      
+    } else {
+      res.status(response.statusCode).end();
+      console.log('error = ' + response.statusCode);
+    }
+  });
+});
+
+app.listen(3000, function () {
+  console.log('http://127.0.0.1:3000/translate app listening on port 3000!');
+});


### PR DESCRIPTION
1. densecap.js -> confidence 순으로 최대 5개의 결과를 합쳐 출력하도록 함.
2. test.html -> live server에서 돌아가는 것을 확인하기 위해 추가함.
3. trans.js -> 결과 값을 이용해 한글로 번역하기 위해 추가함. densecap.js는 모듈로 만들어서 실행되도록 상단에 추가했기 때문에 이 파일을 사용하려면 densecap.js에서 맨 마지막 주석 코드를 활성화시켜야 함. 